### PR TITLE
Make `Zipper.removeTree` removing a tree after being constructed from forest

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "dependencies": {
     "elm": "^0.19.0",
     "elm-format": "^0.8.0",
-    "elm-test": "^0.19.0-beta4",
-    "elm-verify-examples": "^3.0.0"
+    "elm-test": "^0.19.0-rev3",
+    "elm-verify-examples": "^3.0.1"
   },
   "scripts": {
     "test": "elm-format --validate src && elm-test && elm-verify-examples"


### PR DESCRIPTION
As we discussed on Slack, `Zipper.fromTree` could benefit from moving to either parent, previous or next sibling. This PR is implementing the agreed behaviour. 